### PR TITLE
Use is_callable when reordering action hooks

### DIFF
--- a/homepage-control.php
+++ b/homepage-control.php
@@ -241,15 +241,12 @@ final class Homepage_Control {
 				$count = 5;
 				foreach ( $components as $k => $v ) {
 					if (strpos( $v, '@' ) !== FALSE) {
-						$obj_v = explode( '@' , $v );
-						if ( class_exists( $obj_v[0] ) && method_exists( $obj_v[0], $obj_v[1] ) ) {
-							add_action( $this->hook, array( $obj_v[0], $obj_v[1] ), $count );
-						} // End If Statement
-					} else {
-						if ( function_exists( $v ) ) {
-							add_action( $this->hook, esc_attr( $v ), $count );
-						}
-					} // End If Statement
+						$v = explode( '@' , $v );
+					}
+
+					if ( is_callable($v) ) {
+						add_action( $this->hook, $v, $count );
+					}
 
 					$count + 5;
 				}


### PR DESCRIPTION
The [`is_callable`](http://php.net/manual/en/function.is-callable.php) function contains better checks to determine whether a [callable](http://php.net/manual/en/language.types.callable.php) can be called using [`call_user_func_array`](http://php.net/manual/en/function.call-user-func-array.php).

For example, one might have a class which implements the [`__callStatic`](http://php.net/manual/en/language.oop5.overloading.php#object.callstatic) method to call non-existing static methods. In this case, [`method_exists`](http://php.net/manual/en/function.method-exists.php) returns false, whereas the callable works just fine because `__callStatic` handles it. The `is_callable` function returns true in this case.

Furthermore, by using `is_callable` we can simplify this piece of code.